### PR TITLE
fix setImmediate

### DIFF
--- a/duplex.js
+++ b/duplex.js
@@ -26,7 +26,7 @@
 
 module.exports = Duplex;
 var inherits = require('inherits');
-var setImmediate = require('setimmediate');
+require('setimmediate');
 var Readable = require('./readable.js');
 var Writable = require('./writable.js');
 

--- a/readable.js
+++ b/readable.js
@@ -25,7 +25,7 @@ Readable.ReadableState = ReadableState;
 var EE = require('events').EventEmitter;
 var Stream = require('./index.js');
 var Buffer = require('buffer').Buffer;
-var setImmediate = require('setimmediate');
+require('setimmediate');
 var StringDecoder;
 
 var inherits = require('inherits');

--- a/writable.js
+++ b/writable.js
@@ -28,7 +28,7 @@ Writable.WritableState = WritableState;
 
 var inherits = require('inherits');
 var Stream = require('./index.js');
-var setImmediate = require('setimmediate');
+require('setimmediate');
 var Buffer = require('buffer').Buffer;
 
 inherits(Writable, Stream);


### PR DESCRIPTION
the setimmediate module does not attach anything to module.exports, so calls to setImmediate were throwing TypeError: object is not a function

also: https://github.com/jryans/timers-browserify/pull/2
