### PR TITLE
duplex's pipe method should not be inherited from writeable

### DIFF
--- a/duplex.js
+++ b/duplex.js
@@ -32,7 +32,6 @@ var Writable = require('./writable.js');
 
 inherits(Duplex, Readable);
 
-Duplex.prototype.pipe = Writable.prototype.pipe;
 Duplex.prototype.write = Writable.prototype.write;
 Duplex.prototype.end = Writable.prototype.end;
 Duplex.prototype._write = Writable.prototype._write;


### PR DESCRIPTION
should get `pipe` from readable, otherwise transform streams can't pipe

https://github.com/joyent/node/blob/master/lib/_stream_writable.js#L136
