### PR TITLE
upgrade ArrayBuffers and Uint8arrays into Buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "inherits": "~2.0.1",
     "process": "~0.5.1"
   },
+  "scripts": {
+    "test": "node test.js"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/substack/stream-browserify.git"
@@ -22,5 +25,8 @@
     "email": "mail@substack.net",
     "url": "http://substack.net"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "tape": "~2.3.2"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,46 @@
+var util = require('util');
+var path = require('path');
+var test = require('tape');
+
+var Writable = require(path.join(__dirname, 'writable'));
+
+util.inherits(TestWritable, Writable);
+
+function TestWritable(opt) {
+    if (!(this instanceof TestWritable))
+        return new TestWritable(opt);
+    Writable.call(this, opt);
+    this._written = [];
+}
+
+TestWritable.prototype._write = function(chunk, encoding, cb) {
+    this._written.push(chunk);
+    cb();
+};
+
+var typedArray = new Uint8Array(1);
+typedArray[0] = 88;
+
+test('.writable writing ArrayBuffer', function(t) {
+    var writable = new TestWritable();
+    
+    writable.write(typedArray.buffer);
+    writable.end();
+    
+    t.equal(writable._written.length, 1);
+    t.equal(writable._written[0].toString(), 'X')
+    t.end()
+});
+
+
+test('.writable writing Uint8array', function(t) {
+    var writable = new TestWritable();
+    
+    writable.write(typedArray);
+    writable.end();
+    
+    t.equal(writable._written.length, 1);
+    t.equal(writable._written[0].toString(), 'X')
+    t.end()
+});
+

--- a/writable.js
+++ b/writable.js
@@ -167,6 +167,11 @@ Writable.prototype.write = function(chunk, encoding, cb) {
     encoding = null;
   }
 
+  if (chunk instanceof Uint8Array)
+    chunk = new Buffer(chunk);
+  if (chunk instanceof ArrayBuffer)
+    chunk = new Buffer(new Uint8Array(chunk));
+  
   if (Buffer.isBuffer(chunk))
     encoding = 'buffer';
   else if (!encoding)


### PR DESCRIPTION
I ran into the `Invalid non-string/buffer chunk` error from `writable.js` again today when trying to work with https://github.com/brianloveswords/fileliststream, which reads files in the browser as ArrayBuffers and then writes them to a writable stream.

This just wraps any Uint8Arrays or ArrayBuffers in `new Buffer()` so that they can be written.
