### PR TITLE
isArrayBuffer is broken on IE9

### DIFF
--- a/writable.js
+++ b/writable.js
@@ -34,7 +34,7 @@ var isUint8Array = typeof Uint8Array !== 'undefined'
 ;
 var isArrayBuffer = typeof ArrayBuffer !== 'undefined'
   ? function (x) { return x instanceof ArrayBuffer }
-  : function () {
+  : function (x) {
     return x && x.constructor && x.constructor.name === 'ArrayBuffer'
   }
 ;


### PR DESCRIPTION
This pull request adds the `x` argument for the `isArrayBuffer` function that went missing in a previous commit.
