### PR TITLE
use ~ semver for 0.8 compability

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "inherits": "~2.0.1",
-    "readable-stream": "^1.0.27-1"
+    "readable-stream": "~1.0.27-1"
   },
   "devDependencies": {
     "typedarray": "~0.0.5",


### PR DESCRIPTION
The readable-stream dependency currently breaks the 0.8 tests for [bl](https://github.com/rvagg/bl).
This fixes that.
