### PR TITLE
Bump readable-stream to 4.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "inherits": "~2.0.4",
-    "readable-stream": "^3.5.0"
+    "readable-stream": "^4.4.2"
   },
   "devDependencies": {
     "airtap": "^1.0.2",


### PR DESCRIPTION
Some variables are missing on outdated version of `readable-stream` like `Readable.from` and `Readable.fromWeb`.
This PR bumps its version to latest.